### PR TITLE
Remove Beloura Shopping and added stops to Cascaishopping

### DIFF
--- a/facilities/shopping_centers/shopping_centers.csv
+++ b/facilities/shopping_centers/shopping_centers.csv
@@ -115,7 +115,6 @@ SH0113,Centro Comercial Pingo Doce Bela Vista,38.749451,-9.117617,1,0,0,0,,,,,21
 SH0114,Freeport Lisboa Fashion Outlet,38.752294,-8.940800,0,0,0,1,,,,,01,Alcochete,02,Alcochete,15,Setúbal,PT170,AML,,,,010041|010135|010136
 SH0115,Centro Comercial de Alvalade,38.753286,-9.145038,1,0,0,0,,,,,54,Alvalade,06,Lisboa,11,Lisboa,PT170,AML,,,,
 SH0116,Centro Comercial das Pedralvas,38.753884,-9.205210,1,0,0,0,,,,,08,Benfica,06,Lisboa,11,Lisboa,PT170,AML,,,,060043|060044
-SH0117,Beloura Shopping,38.759836,-9.386566,1,0,0,0,,,,,28,"União das freguesias de Sintra (Santa Maria e São Miguel, São Martinho e São Pedro de Penaferrim)",11,Sintra,11,Lisboa,PT170,AML,,,,172285|172287|172309
 SH0118,Centro Comercial Alvaláxia,38.761201,-9.159537,1,0,0,0,,,,,18,Lumiar,06,Lisboa,11,Lisboa,PT170,AML,,,,060155|060156|060171|060226|060259|060286|060301|060302|060303|060304|060305|060306|060308|060310|060311|060312|060314|060316|060337|060339|060341|060369|061200
 SH0119,Spacio Shopping,38.762299,-9.114931,1,0,0,0,,,,,33,Olivais,06,Lisboa,11,Lisboa,PT170,AML,,,,
 SH0120,Galeria Quinta do Lambert,38.763182,-9.152676,1,0,0,0,,,,,18,Lumiar,06,Lisboa,11,Lisboa,PT170,AML,,,,


### PR DESCRIPTION
Fixes issues #5 and #4 by removing the now-defunct Beloura Shopping (it's been turned into an university) and added stops to Cascaishopping (CascaiShopping Terminal and the two stops near A16 that serve this shopping centre)